### PR TITLE
Update jest.Matchers in index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,7 @@ declare global {
     }
   }
   namespace jest {
-    interface Matchers<T> {
+    interface Matchers<R> {
       toBeObservable: any;
       toHaveSubscriptions: any;
     }


### PR DESCRIPTION
Update `jest.Matchers<T>` to `jest.Matchers<R>` to solve the error `All declarations of 'Matchers' must have identical type parameters` and `Generic type 'Matchers<R, T>' requires 2 type argument(s)`

Ref: #28
